### PR TITLE
Update event descriptions in events.js

### DIFF
--- a/content/events.js
+++ b/content/events.js
@@ -1,17 +1,12 @@
 events = {
     "events": [
         {
-            "title": "No Kings II October 18",
-            "body": "Join people around the country in resisting vote-stealing, masked gunmen in our streets, acceleration of the climate crisis, lying, lawbreaking, and attacks on just about everyone so the rich can get richer.  Saturday October 18, starting at 11 am at the Eureka co-op and walking on the sidewalks in groups to the 4th street side of the courthouse.  On the 5th street side, the rally goes from noon-2pm.  Bring signs and energy."
-        },
-       {
             "title": "Celebrate Queer History",
             "body": "Queer Humboldt, the Eric Rofes center at Cal Poly Humboldt and Equity Arcata are inviting us to a Queer History Party. Lots of community groups with activities, a costume contest for Favorite Queer Person from History, a drag show, and food and drink trucks.  The LWord will have coloring sheets of historic Pride drawings--to help table, email suejh@humboldt1.com. Sunday October 26, 4-7 pm, D street Neighborhood Center in Arcata. info Aisha@queerhumboldt.org."
         },
         {
             "title": "Dia de los Muertos",
-            "body": "Join Centro del Pueblo in Celebrating Dia de los Muertos. There's a masked parade in old town Eureka on October 30 starting at 6 pm, and a festival with Catrinas, dancing, alters, and more at the Eureka theater 4-6 pm on November 2, and lots of ways to be more involved.
-For the parade, there are mask workshops at Centro's Eureka office (3008 Broadway) Fridays Oct. 17 & 24, 6-7:30pm. For the La Catrina show, there are rehearsals through October, on Thursdays at the Eureka office 6-7:45pm and Saturdays at the Jardín Santuario in Arcata 9:30- 11am. Contact laura@cdpueblo.com to get involved. You can also make Sugar skulls at el Jardín Santuario 10/18 and 10/25,12pm. And celebrate the harvest at CdP's farm, October 17-19 starting at 10 am. cdpueblo.com"
+            "body": "Join Centro del Pueblo in Celebrating Dia de los Muertos. There's a masked parade in old town Eureka on October 30 starting at 6 pm, and a festival with Catrinas, dancing, alters, and more at the Eureka theater 4-6 pm on November 2. cdpueblo.com"
         },
     ]
 };


### PR DESCRIPTION
Removed details from the 'No Kings II October 18' event and simplified the 'Dia de los Muertos' event description.