### PR TITLE
Remove Queer History event and update Dia de los Muertos

### DIFF
--- a/content/events.js
+++ b/content/events.js
@@ -1,12 +1,8 @@
 events = {
     "events": [
-        {
-            "title": "Celebrate Queer History",
-            "body": "Queer Humboldt, the Eric Rofes center at Cal Poly Humboldt and Equity Arcata are inviting us to a Queer History Party. Lots of community groups with activities, a costume contest for Favorite Queer Person from History, a drag show, and food and drink trucks.  The LWord will have coloring sheets of historic Pride drawings--to help table, email suejh@humboldt1.com. Sunday October 26, 4-7 pm, D street Neighborhood Center in Arcata. info Aisha@queerhumboldt.org."
-        },
-        {
+         {
             "title": "Dia de los Muertos",
-            "body": "Join Centro del Pueblo in Celebrating Dia de los Muertos with a festival at the Eureka theater 4-6 pm on Sunday November 2.  There will be Catrinas, dancing, alters, and more. cdpueblo.com"
+            "body": 'Join Centro del Pueblo in Celebrating Dia de los Muertos with a festival at the Eureka theater 4-6 pm on Sunday November 2.  There will be Catrinas, dancing, alters, and more. <a href="http://cdpueblo.com/">cdpueblo.com</a>'
         },
          {
             "title": "Caminata procession",


### PR DESCRIPTION
Removed the event 'Celebrate Queer History' and updated the 'Dia de los Muertos' event description with a link.