### PR TITLE
Fix URL in 'Trans Remembrance and Resistance' event

### DIFF
--- a/content/events.js
+++ b/content/events.js
@@ -2,7 +2,7 @@ events = {
     "events": [
         {
             "title": "Trans Remembrance and Resistance",
-            "body": 'There are events in Del Norte and around Humboldt Bay to remember Trans* lives lost to violence and to celebrate and support our communites.  In Del Norte, the DNATL LGBTQ Project is hosting a Transgender Day of Remembrance & Resilience on Nov. 20th starting at 6pm. St Pauls Episcopal, 220 E Macken St. Crescent City. Around Humboldt Bay, The Eureka Sisters are hosting a week of events, including speed friending, a talking circle, film festival, art & poetry, the TRANScending the Veil ritual on the Arcata Plaza at 5 pm on Thursday Nov. 20, a music and drag show, and more. <a href="http//eurekasisters.org">eurekasisters.org</a>'
+            "body": 'There are events in Del Norte and around Humboldt Bay to remember Trans* lives lost to violence and to celebrate and support our communites.  In Del Norte, the DNATL LGBTQ Project is hosting a Transgender Day of Remembrance & Resilience on Nov. 20th starting at 6pm. St Pauls Episcopal, 220 E Macken St. Crescent City. Around Humboldt Bay, The Eureka Sisters are hosting a week of events, including speed friending, a talking circle, film festival, art & poetry, the TRANScending the Veil ritual on the Arcata Plaza at 5 pm on Thursday Nov. 20, a music and drag show, and more. <a href="https://www.eurekasisters.org/">eurekasisters.org</a>'
         },
         {   
             "title": "Hands Off Venezuela",


### PR DESCRIPTION
Updated the event details for 'Trans Remembrance and Resistance' to include a correct URL.